### PR TITLE
[FEAT]: add theme toggle

### DIFF
--- a/app/(panel)/layout.tsx
+++ b/app/(panel)/layout.tsx
@@ -22,7 +22,7 @@ export default async function Panel({
 }: {
   children: React.ReactNode;
 }) {
-  await checkUserSession();
+  // await checkUserSession();
 
   return <PanelLayout>{children}</PanelLayout>;
 }

--- a/app/(panel)/layout.tsx
+++ b/app/(panel)/layout.tsx
@@ -22,7 +22,7 @@ export default async function Panel({
 }: {
   children: React.ReactNode;
 }) {
-  // await checkUserSession();
+  await checkUserSession();
 
   return <PanelLayout>{children}</PanelLayout>;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,8 @@ export default async function Layout({
       <body className={helvetica.className}>
         <ThemeProvider
           attribute="class"
-          enableSystem={false}
+          defaultTheme="dark"
+          enableSystem
           disableTransitionOnChange
         >
           <TrpcProvider>{children}</TrpcProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default async function Layout({
       <body className={helvetica.className}>
         <ThemeProvider
           attribute="class"
-          enableSystem
+          enableSystem={false}
           disableTransitionOnChange
         >
           <TrpcProvider>{children}</TrpcProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,6 @@ export default async function Layout({
       <body className={helvetica.className}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
         >

--- a/modules/landing/components/companies-section/index.tsx
+++ b/modules/landing/components/companies-section/index.tsx
@@ -42,12 +42,31 @@ const CompaniesSection = () => {
                     className="grid grid-cols-2 gap-8 text-gray-500 sm:gap-12 md:grid-cols-3 lg:grid-cols-6 dark:text-gray-400">
                     {
                         companies.map((company, index) => {
-                            return(
-                                <a key={`LANDING_COMPANY_${index}`} href="#" className="flex justify-between items-center flex-col gap-2 hover:scale-110 transition-transform duration-300">
-                                    <Image src={company.logo} alt={company.name} width={100} height={100} />
-                                    <p className="font-bold text-2xl text-center">{company.name}</p>
-                                </a>
-                            )
+                            return (
+                              <a
+                                key={`LANDING_COMPANY_${index}`}
+                                href="#"
+                                className="flex justify-between items-center flex-col gap-2 hover:scale-110 transition-transform duration-300"
+                              >
+                                <div
+                                  className={
+                                    company.name === 'GM'
+                                      ? 'bg-black rounded-[17px]'
+                                      : ''
+                                  }
+                                >
+                                  <Image
+                                    src={company.logo}
+                                    alt={company.name}
+                                    width={100}
+                                    height={100}
+                                  />
+                                </div>
+                                <p className="font-bold text-2xl text-center">
+                                  {company.name}
+                                </p>
+                              </a>
+                            );
                         })
                     }
 

--- a/modules/landing/components/features-section/index.tsx
+++ b/modules/landing/components/features-section/index.tsx
@@ -54,14 +54,14 @@ const FeaturesSection = () => {
             <CardBody className="relative group/card  hover:shadow-2xl hover:shadow-primary/[0.2] bg-black dark:border-white/[0.2] w-auto h-auto rounded-xl p-6 border">
               <CardItem
                 translateZ="50"
-                className="text-xl font-bold text-neutral-600 dark:text-white"
+                className="text-xl font-bold text-white"
               >
                 {item.title}
               </CardItem>
               <CardItem
                 as="p"
                 translateZ="60"
-                className="text-neutral-500 text-sm max-w-sm mt-2 dark:text-neutral-300"
+                className="text-sm max-w-sm mt-2 text-neutral-300"
               >
                 {item.description}
               </CardItem>

--- a/modules/landing/components/hero-section/index.tsx
+++ b/modules/landing/components/hero-section/index.tsx
@@ -19,7 +19,7 @@ const HeroSection = () => {
         </span>
         <div className="flex flex-col bg-background rounded-xl overflow-hidden">
           <span className="w-full bg-primary text-white p-1">Terminal</span>
-          <span className="p-3 text-white">pip3 install -U swarms</span>
+          <span className="p-3">pip3 install -U swarms</span>
         </div>
         <div className="flex gap-4 mt-8">
           <Link href={PLATFORM.DASHBOARD} target="_blank">
@@ -40,12 +40,10 @@ const HeroSection = () => {
             <Button
               className={cn(
                 'text-base flex gap-2 font-normal',
-                'bg-white',
-                'hover:bg-white/90',
-                'text-background',
                 'px-10 py-6',
                 'rounded-md'
               )}
+              variant="foreground"
             >
               <Github size={18} />
               Github

--- a/modules/landing/components/open-source-section/index.tsx
+++ b/modules/landing/components/open-source-section/index.tsx
@@ -17,10 +17,10 @@ const OpenSourceSection = () => {
           fill="white"
           /> */}
           <div className=" p-4 max-w-7xl  mx-auto relative z-10  w-full pt-20 md:pt-0">
-            <h1 className="text-4xl md:text-7xl font-bold text-center bg-clip-text text-transparent bg-gradient-to-b from-neutral-50 to-neutral-400 bg-opacity-50">
+            <h1 className="text-4xl md:text-7xl font-bold text-center bg-clip-text text-transparent bg-gradient-to-b from-neutral-950 to-neutral-600 dark:from-neutral-50 dark:to-neutral-400 bg-opacity-50">
             Everything Is <br /> Open Source
             </h1>
-            <p className="mt-4 font-normal text-base text-neutral-300 max-w-lg text-center mx-auto">
+            <p className="mt-4 font-normal text-base text-neutral-700 dark:text-neutral-300 max-w-lg text-center mx-auto">
               TGSC is radically focused on transparency and open source. We believe that the best way to build a better future is by working together.
             </p>
           </div>
@@ -35,7 +35,7 @@ const OpenSourceSection = () => {
               }}
               className="flex flex-col items-center gap-10"
             >
-              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl font-bold"> Join Community </p>}>
+              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl text-secondary font-bold"> Join Community </p>}>
               <div className="w-24 h-24 md:w-32 md:h-32">
                 <Image
                   alt="discord" 
@@ -55,7 +55,7 @@ const OpenSourceSection = () => {
               }}
               className="flex flex-col items-center gap-10"
             >
-              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl font-bold"> Join Us </p>}>
+              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl text-secondary font-bold"> Join Us </p>}>
               <div className="w-28 h-28 md:w-60 md:h-60">
                 <Image
                   alt="github" 
@@ -75,7 +75,7 @@ const OpenSourceSection = () => {
               }}
               className="flex flex-col items-center gap-10"
             >
-              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl font-bold"> Follow Us on X </p>}>
+              <AnimatedTooltip tooltip={<p className="text-base md:text-2xl text-secondary font-bold"> Follow Us on X </p>}>
                 <div className="w-24 h-24 md:w-32 md:h-32">
                   <Image
                     alt="twitter" 

--- a/modules/landing/components/visualization-section/index.tsx
+++ b/modules/landing/components/visualization-section/index.tsx
@@ -2,6 +2,7 @@
 import { cn } from "@/shared/utils/cn";
 import hslToHex from "@/shared/utils/hsl-to-hex";
 import { motion, MotionValue, useScroll, useTransform } from "framer-motion";
+import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
@@ -19,12 +20,14 @@ export const GoogleGeminiEffect = ({
   description?: string;
   className?: string;
 }) => {
+  const { theme } = useTheme();
   const [primaryColor, setPrimaryColor] = useState("");
   const ref = React.useRef(null);
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start start", "end start"],
   });
+
 
   const pathLengthFirst = useTransform(scrollYProgress, [0, 0.8], [0.2, 1.2]);
   const pathLengthSecond = useTransform(scrollYProgress, [0, 0.8], [0.15, 1.2]);
@@ -43,6 +46,8 @@ export const GoogleGeminiEffect = ({
     visible: { opacity: 1 },
   };
   const [textContent, setTextContent] = useState({ title: "", description: "" });
+
+  const strokeColor = theme === 'dark' ? '#FFF' : '#00000056';
 
   useEffect(() => {
     const updateTextContent = () => {
@@ -99,10 +104,10 @@ export const GoogleGeminiEffect = ({
           initial="hidden"
           animate="visible"
         >
-          <h4 className="text-4xl md:text-7xl font-normal pb-4 text-center bg-clip-text text-transparent bg-gradient-to-b from-neutral-100 to-neutral-300">
+          <h4 className="text-4xl md:text-7xl font-normal pb-4 text-center bg-clip-text text-transparent bg-gradient-to-b from-neutral-900 to-neutral-600 dark:from-neutral-100 dark:to-neutral-300">
             {textContent.title}
           </h4>
-          <p className="text-base md:text-xl font-normal text-center text-neutral-400 mt-4 max-w-lg mx-auto">
+          <p className="text-base md:text-xl font-normal text-center text-neutral-600 dark:text-neutral-400 mt-4 max-w-lg mx-auto">
             {textContent.description}
           </p>
         </motion.div>
@@ -193,7 +198,7 @@ export const GoogleGeminiEffect = ({
 
           <path
             d="M0 663C145.5 663 191 666.265 269 647C326.5 630 339.5 621 397.5 566C439 531.5 455 529.5 490 523C509.664 519.348 521 503.736 538 504.236C553.591 504.236 562.429 514.739 584.66 522.749C592.042 525.408 600.2 526.237 607.356 523.019C624.755 515.195 641.446 496.324 657 496.735C673.408 496.735 693.545 519.572 712.903 526.769C718.727 528.934 725.184 528.395 730.902 525.965C751.726 517.115 764.085 497.106 782 496.735C794.831 496.47 804.103 508.859 822.469 518.515C835.13 525.171 850.214 526.815 862.827 520.069C875.952 513.049 889.748 502.706 903.5 503.736C922.677 505.171 935.293 510.562 945.817 515.673C954.234 519.76 963.095 522.792 972.199 524.954C996.012 530.611 1007.42 534.118 1034 549C1077.5 573.359 1082.5 594.5 1140 629C1206 670 1328.5 662.5 1440 662.5"
-            stroke="#FFF"
+            stroke={strokeColor}
             strokeWidth="2"
             fill="none"
             pathLength={1}
@@ -201,7 +206,7 @@ export const GoogleGeminiEffect = ({
           />
           <path
             d="M0 587.5C147 587.5 277 587.5 310 573.5C348 563 392.5 543.5 408 535C434 523.5 426 526.235 479 515.235C494 512.729 523 510.435 534.5 512.735C554.5 516.735 555.5 523.235 576 523.735C592 523.735 616 496.735 633 497.235C648.671 497.235 661.31 515.052 684.774 524.942C692.004 527.989 700.2 528.738 707.349 525.505C724.886 517.575 741.932 498.33 757.5 498.742C773.864 498.742 791.711 520.623 810.403 527.654C816.218 529.841 822.661 529.246 828.451 526.991C849.246 518.893 861.599 502.112 879.5 501.742C886.47 501.597 896.865 506.047 907.429 510.911C930.879 521.707 957.139 519.639 982.951 520.063C1020.91 520.686 1037.5 530.797 1056.5 537C1102.24 556.627 1116.5 570.704 1180.5 579.235C1257.5 589.5 1279 587 1440 588"
-            stroke="#FFF"
+            stroke={strokeColor}
             strokeWidth="2"
             fill="none"
             pathLength={1}
@@ -209,7 +214,7 @@ export const GoogleGeminiEffect = ({
           />
           <path
             d="M0 514C147.5 514.333 294.5 513.735 380.5 513.735C405.976 514.94 422.849 515.228 436.37 515.123C477.503 514.803 518.631 506.605 559.508 511.197C564.04 511.706 569.162 512.524 575 513.735C588 516.433 616 521.702 627.5 519.402C647.5 515.402 659 499.235 680.5 499.235C700.5 499.235 725 529.235 742 528.735C757.654 528.735 768.77 510.583 791.793 500.59C798.991 497.465 807.16 496.777 814.423 499.745C832.335 507.064 850.418 524.648 866 524.235C882.791 524.235 902.316 509.786 921.814 505.392C926.856 504.255 932.097 504.674 937.176 505.631C966.993 511.248 970.679 514.346 989.5 514.735C1006.3 515.083 1036.5 513.235 1055.5 513.235C1114.5 513.235 1090.5 513.235 1124 513.235C1177.5 513.235 1178.99 514.402 1241 514.402C1317.5 514.402 1274.5 512.568 1440 513.235"
-            stroke="#FFF"
+            stroke={strokeColor}
             strokeWidth="2"
             fill="none"
             pathLength={1}
@@ -217,7 +222,7 @@ export const GoogleGeminiEffect = ({
           />
           <path
             d="M0 438.5C150.5 438.5 261 438.318 323.5 456.5C351 464.5 387.517 484.001 423.5 494.5C447.371 501.465 472 503.735 487 507.735C503.786 512.212 504.5 516.808 523 518.735C547 521.235 564.814 501.235 584.5 501.235C604.5 501.235 626 529.069 643 528.569C658.676 528.569 672.076 511.63 695.751 501.972C703.017 499.008 711.231 498.208 718.298 501.617C735.448 509.889 751.454 529.98 767 529.569C783.364 529.569 801.211 507.687 819.903 500.657C825.718 498.469 832.141 499.104 837.992 501.194C859.178 508.764 873.089 523.365 891 523.735C907.8 524.083 923 504.235 963 506.735C1034.5 506.735 1047.5 492.68 1071 481.5C1122.5 457 1142.23 452.871 1185 446.5C1255.5 436 1294 439 1439.5 439"
-            stroke="#FFF"
+            stroke={strokeColor}
             strokeWidth="2"
             fill="none"
             pathLength={1}
@@ -225,7 +230,7 @@ export const GoogleGeminiEffect = ({
           />
           <path
             d="M0.5 364C145.288 362.349 195 361.5 265.5 378C322 391.223 399.182 457.5 411 467.5C424.176 478.649 456.916 491.677 496.259 502.699C498.746 503.396 501.16 504.304 503.511 505.374C517.104 511.558 541.149 520.911 551.5 521.236C571.5 521.236 590 498.736 611.5 498.736C631.5 498.736 652.5 529.236 669.5 528.736C685.171 528.736 697.81 510.924 721.274 501.036C728.505 497.988 736.716 497.231 743.812 500.579C761.362 508.857 778.421 529.148 794 528.736C810.375 528.736 829.35 508.68 848.364 502.179C854.243 500.169 860.624 500.802 866.535 502.718C886.961 509.338 898.141 519.866 916 520.236C932.8 520.583 934.5 510.236 967.5 501.736C1011.5 491 1007.5 493.5 1029.5 480C1069.5 453.5 1072 440.442 1128.5 403.5C1180.5 369.5 1275 360.374 1439 364"
-            stroke="#FFF"
+            stroke={strokeColor}
             strokeWidth="2"
             fill="none"
             pathLength={1}

--- a/modules/landing/components/visualization-section/index.tsx
+++ b/modules/landing/components/visualization-section/index.tsx
@@ -47,7 +47,7 @@ export const GoogleGeminiEffect = ({
   };
   const [textContent, setTextContent] = useState({ title: "", description: "" });
 
-  const strokeColor = theme === 'dark' ? '#FFF' : '#00000056';
+  const strokeColor = theme === 'light' ? '#00000056' : '#FFF';
 
   useEffect(() => {
     const updateTextContent = () => {

--- a/modules/landing/components/visualization-section/index.tsx
+++ b/modules/landing/components/visualization-section/index.tsx
@@ -20,7 +20,7 @@ export const GoogleGeminiEffect = ({
   description?: string;
   className?: string;
 }) => {
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
   const [primaryColor, setPrimaryColor] = useState("");
   const ref = React.useRef(null);
   const { scrollYProgress } = useScroll({
@@ -47,7 +47,9 @@ export const GoogleGeminiEffect = ({
   };
   const [textContent, setTextContent] = useState({ title: "", description: "" });
 
-  const strokeColor = theme === 'light' ? '#00000056' : '#FFF';
+  console.log({ resolvedTheme })
+
+  const strokeColor = theme === 'light' || resolvedTheme === "light" ? '#00000056' : '#FFF';
 
   useEffect(() => {
     const updateTextContent = () => {

--- a/modules/landing/components/visualization-section/index.tsx
+++ b/modules/landing/components/visualization-section/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
+import { StrokeColor, THEMES } from "@/shared/constants/theme";
 
 const transition = {
   duration: 0,
@@ -47,9 +48,10 @@ export const GoogleGeminiEffect = ({
   };
   const [textContent, setTextContent] = useState({ title: "", description: "" });
 
-  console.log({ resolvedTheme })
-
-  const strokeColor = theme === 'light' || resolvedTheme === "light" ? '#00000056' : '#FFF';
+  const strokeColor =
+  theme === THEMES.LIGHT || resolvedTheme === THEMES.LIGHT
+    ? StrokeColor.DARK
+    : StrokeColor.LIGHT;
 
   useEffect(() => {
     const updateTextContent = () => {

--- a/modules/platform/account/components/card-manager/index.tsx
+++ b/modules/platform/account/components/card-manager/index.tsx
@@ -123,7 +123,7 @@ const CardManagerInside = () => {
         </form>
       </Modal>
       <div className="flex flex-col gap-4 w-full border rounded-md p-4 text-card-foreground">
-        <h1 className="text-base font-bold text-white">Manage Cards</h1>
+        <h1 className="text-base font-bold">Manage Cards</h1>
         <div className="flex flex-col items-center justify-center p-1 gap-2">
           {manager.methods.isLoading && <LoadingSpinner />}
           {

--- a/modules/platform/account/index.tsx
+++ b/modules/platform/account/index.tsx
@@ -11,7 +11,7 @@ export default function Account() {
     <section className="w-full mb-32">
       <div>
         <div className="flex flex-col">
-          <h1 className="text-3xl font-extrabold text-white sm:text-4xl">
+          <h1 className="text-3xl font-extrabold sm:text-4xl">
             Account
           </h1>
           {/* charge button */}
@@ -21,7 +21,7 @@ export default function Account() {
             <SubscriptionStatus />
 
             <div className="flex flex-col gap-2">
-              <h2 className="text-white text-xl font-bold">Password</h2>
+              <h2 className="text-xl font-bold">Password</h2>
               <Link href={AUTH.CHANGE_PASSWORD}>
                 <Button variant={'outline'}>Change password</Button>
               </Link>

--- a/modules/platform/account/index.tsx
+++ b/modules/platform/account/index.tsx
@@ -5,15 +5,14 @@ import Credit from './components/credit';
 import SubscriptionStatus from './components/subscription-status';
 import Link from 'next/link';
 import { AUTH } from '@/shared/constants/links';
+import ThemeToggle from '@/shared/components/theme-toggle';
 
 export default function Account() {
   return (
     <section className="w-full mb-32">
       <div>
         <div className="flex flex-col">
-          <h1 className="text-3xl font-extrabold sm:text-4xl">
-            Account
-          </h1>
+          <h1 className="text-3xl font-extrabold sm:text-4xl">Account</h1>
           {/* charge button */}
           <div className="w-full my-8 flex flex-col gap-4 md:w-2/3  lg:w-2/6">
             <CardManager />
@@ -26,6 +25,8 @@ export default function Account() {
                 <Button variant={'outline'}>Change password</Button>
               </Link>
             </div>
+
+            <ThemeToggle />
           </div>
           {/* show credit */}
         </div>

--- a/modules/platform/account/index.tsx
+++ b/modules/platform/account/index.tsx
@@ -14,7 +14,7 @@ export default function Account() {
         <div className="flex flex-col">
           <h1 className="text-3xl font-extrabold sm:text-4xl">Account</h1>
           {/* charge button */}
-          <div className="w-full my-8 flex flex-col gap-4 md:w-2/3  lg:w-2/6">
+          <div className="w-full my-8 flex flex-col gap-4 md:w-2/3 xl:w-2/6">
             <CardManager />
             {/* <Credit /> */}
             <SubscriptionStatus />

--- a/modules/platform/dashboard/index.tsx
+++ b/modules/platform/dashboard/index.tsx
@@ -21,7 +21,7 @@ const Dashboard = () => {
   ).split(' ');
   return (
     <div className="w-full flex flex-col">
-      <h1 className="text-3xl font-extrabold text-white sm:text-4xl">
+      <h1 className="text-3xl font-extrabold sm:text-4xl">
         Home
       </h1>
       <div className="mt-4 flex gap-4 max-md:flex-col">
@@ -82,41 +82,41 @@ const Dashboard = () => {
           <div className="flex flex-col gap-2 mt-4">
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 Access to the best Multi-Modal Models
               </span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 Access to the swarms for special workflows
               </span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">Usage-Based Pricing for models and swarms</span>
+              <span>Usage-Based Pricing for models and swarms</span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 99% Uptime with 24/7 Support
               </span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 The Explorer: Explore Multi-Modal Models and Swarms
               </span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 Early Access to new models, swarms, and features!
               </span>
             </div>
             <div className="flex  items-center gap-2">
               <Check size={24} />
-              <span className="text-white">
+              <span>
                 Coupons and Discounts for usage-based pricing!
               </span>
             </div>

--- a/modules/platform/playground/components/message/index.tsx
+++ b/modules/platform/playground/components/message/index.tsx
@@ -53,7 +53,7 @@ const TextMessageRender = ({
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         className={cn(
-          'w-full p-1 bg-transparent focus:bg-background focus:outline-2 outline-purple-500 rounded-md resize-none overflow-scroll'
+          'w-full p-1 bg-transparent focus:bg-background focus:outline-2 outline-purple-500 border border-gray-700/50 focus:border-none rounded-md resize-none overflow-scroll'
         )}
         value={text}
         onChange={(e) => updateContentText(e.target.value)}
@@ -160,7 +160,7 @@ const MessageItem = ({
         accept="image/*"
         onChange={onChooseFile}
       />
-      <div className="border-b-2 border-gray-700/50 group">
+      <div className="border-b-2 border-gray-700/50 group flex flex-col">
         <div
           className={cn(
             'flex flex-col px-4',
@@ -170,19 +170,19 @@ const MessageItem = ({
         >
           <div className="flex py-4">
             <div
-              className="w-3/12 select-none cursor-pointer"
+              className="w-3/12 select-none cursor-pointer -translate-x-3 xl:translate-x-0"
               onClick={toggleRole}
             >
               <span
                 className={cn(
-                  'text-sm group-hover:bg-gray-700 p-1 rounded-lg text-white uppercase',
-                  isFocused && 'bg-gray-700'
+                  'text-xs xl:text-sm group-hover:bg-gray-700 group-hover:text-white p-1 rounded-lg uppercase',
+                  isFocused && 'bg-gray-700 text-white'
                 )}
               >
                 {message.role}
               </span>
             </div>
-            <div className="w-8/12">
+            <div className="flex-grow group-hover:flex-grow-0 group-hover:w-8/12">
               {message.content &&
                 typeof message.content === 'object' &&
                 message.content.map((content, j) => {
@@ -234,7 +234,7 @@ const MessageItem = ({
                 )
               }
             </div>
-            <div className="w-1/12 flex justify-end">
+            <div className="w-0 flex justify-end group-hover:w-1/12">
               <CircleMinus
                 onClick={remove}
                 className={cn(

--- a/modules/platform/playground/index.tsx
+++ b/modules/platform/playground/index.tsx
@@ -22,10 +22,10 @@ const Playground = () => {
 
   return (
     <div className="w-full flex flex-col">
-      <h1 className="text-3xl font-extrabold text-white sm:text-4xl">
+      <h1 className="text-3xl font-extrabold sm:text-4xl">
         Playground
       </h1>
-      <div className="w-full h-full flex gap-4 py-4 overflow-hidden px-1 max-md:flex-col-reverse">
+      <div className="w-full h-full flex gap-4 py-4 overflow-hidden px-1 max-md:flex-col-reverse mt-4 sm:mt-0">
         <div className="max-lg:hidden w-2/6 ">
           <Textarea
             className="h-full resize-none"
@@ -69,7 +69,7 @@ const Playground = () => {
             {/* add message */}
             <div
               onClick={playground.addMessage}
-              className="w-full flex gap-2 py-3 p-2  px-4 cursor-pointer hover:bg-gray-700/50 rounded-md"
+              className="w-full flex gap-2 py-3 p-2  px-4 cursor-pointer hover:bg-gray-700/50 hover:text-white rounded-md mt-2"
             >
               <Plus size={20} />
               <span>Add message</span>

--- a/modules/platform/usage/index.tsx
+++ b/modules/platform/usage/index.tsx
@@ -55,7 +55,7 @@ const Usage = () => {
   };
   return (
     <div className="flex flex-col w-full">
-      <h1 className="text-3xl font-extrabold text-white sm:text-4xl">Usage</h1>
+      <h1 className="text-3xl font-extrabold sm:text-4xl">Usage</h1>
       <div className="mt-4 w-1/2 h-1/2">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data}>

--- a/modules/pricing/index.tsx
+++ b/modules/pricing/index.tsx
@@ -109,16 +109,16 @@ const Pricing = () => {
             </svg>
             <div className="relative flex flex-col items-center justify-center max-w-6xl px-8 py-12 mx-auto lg:py-24">
                 <div>
-                    <span className="text-6xl font-bold tracking-wide text-white uppercase">Pricing</span>
+                    <span className="text-6xl font-bold tracking-wide text-foreground uppercase">Pricing</span>
                 </div>
                 <div className="grid grid-cols-1 gap-8 mt-12 lg:ap-2 lg:grid-cols-2">
                     <div className="lg:order-last max-w-sm">
                         <div className="flex flex-col">
                             <div className="p-8 shadow-2xl rounded-3xl bg-primary ring-1 ring-white/10">
                                 <div className="flex items-center justify-between">
-                                    <div className="flex items-center gap-3">
+                                    <div className="flex items-center gap-3 text-white">
                                         <Gem />
-                                        <p className="text-base font-medium text-white uppercase">
+                                        <p className="text-base font-medium uppercase">
                                             {pricingData.Enterprise.title}
                                         </p>
                                     </div>
@@ -145,10 +145,10 @@ const Pricing = () => {
                                 !!pricingData.Enterprise.features.length &&
                                 <div className="px-8">
                                     <div>
-                                        <p className="mt-4 text-lg font-medium text-white uppercase lg:mt-8">
+                                        <p className="mt-4 text-lg font-medium text-foreground uppercase lg:mt-8">
                                             Features
                                         </p>
-                                        <ul className="gap-4 mt-4 space-y-3 text-gray-300 list-none" role="list">
+                                        <ul className="gap-4 mt-4 space-y-3 text-gray-700 dark:text-gray-300 list-none" role="list">
                                             {
                                                 pricingData.Enterprise.features.map((item, index) => {
                                                     return (
@@ -169,9 +169,9 @@ const Pricing = () => {
                         <div className="flex flex-col">
                             <div className="p-8 rounded-3xl bg-black ring-1 ring-white/10 shadow-2xl">
                                 <div className="flex justify-between">
-                                    <div className="flex items-center gap-3">
+                                    <div className="flex items-center gap-3 text-white">
                                         <Bolt />
-                                        <p className="text-base font-medium text-white uppercase">
+                                        <p className="text-base font-medium uppercase">
                                             {pricingData.Premium.title}
                                         </p>
                                     </div>
@@ -188,8 +188,8 @@ const Pricing = () => {
                                     <Link
                                         className={cn(
                                             "items-center justify-between inline-flex w-full font-medium px-6 py-2.5 text-center", 
-                                            "text-white duration-200 bg-white/5 border", 
-                                            "border-white/5 rounded-xl h-14 hover:bg-white/10 hover:border-white/10",
+                                            "text-white duration-200 bg-white/10 dark:bg-white/5 border", 
+                                            "border-white/5 dark:border-white/10 rounded-xl h-14 hover:bg-white/10 hover:border-white/10",
                                              "focus:outline-none focus-visible:outline-black text-base focus-visible:ring-black"
                                         )}
                                         href={pricingData.Premium.link}>
@@ -201,10 +201,10 @@ const Pricing = () => {
                             </div>
                             <div className="px-8">
                                 <div>
-                                    <p className="mt-4 text-lg font-medium text-white uppercase lg:mt-8">
+                                    <p className="mt-4 text-lg font-medium text-foreground uppercase lg:mt-8">
                                         Features
                                     </p>
-                                    <ul className="order-last gap-4 mt-4 space-y-3 text-gray-300 list-none" role="list">
+                                    <ul className="order-last gap-4 mt-4 space-y-3 text-gray-700 dark:text-gray-300 list-none" role="list">
                                         {
                                             pricingData.Premium.features.map((item, index) => {
                                                 return (

--- a/modules/pricing/index.tsx
+++ b/modules/pricing/index.tsx
@@ -109,7 +109,7 @@ const Pricing = () => {
             </svg>
             <div className="relative flex flex-col items-center justify-center max-w-6xl px-8 py-12 mx-auto lg:py-24">
                 <div>
-                    <span className="text-6xl font-bold tracking-wide text-foreground uppercase">Pricing</span>
+                    <span className="text-6xl font-bold tracking-wide uppercase">Pricing</span>
                 </div>
                 <div className="grid grid-cols-1 gap-8 mt-12 lg:ap-2 lg:grid-cols-2">
                     <div className="lg:order-last max-w-sm">

--- a/shared/components/panel-layout/components/sidebar.tsx
+++ b/shared/components/panel-layout/components/sidebar.tsx
@@ -144,7 +144,7 @@ const PanelLayoutSidebar = () => {
         <Drawer direction="left">
           <DrawerTrigger asChild>
             <div className="flex w-full h-auto py-2 backdrop-blur-md bg-background/70 top-0 absolute z-[20] ">
-              <Button className="text-white" variant="link">
+              <Button className="text-foreground" variant="link">
                 <Menu />
               </Button>
             </div>

--- a/shared/components/theme-toggle/components/theme-card.tsx
+++ b/shared/components/theme-toggle/components/theme-card.tsx
@@ -62,7 +62,9 @@ export default function ThemeCard({
               : ''
           )}
         />
-        <span className="first-letter:capitalize">{themeLabel} default</span>
+        <span className="first-letter:capitalize">
+          {themeLabel} {isDark && '(default)'}
+        </span>
       </div>
     </div>
   );

--- a/shared/components/theme-toggle/components/theme-card.tsx
+++ b/shared/components/theme-toggle/components/theme-card.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cn } from '@/shared/utils/cn';
+import Logo from '@/shared/components/icons/Logo';
+
+interface ThemeCardProps {
+  themeLabel: string;
+  disabled?: boolean;
+  isSelected?: boolean;
+  handleTheme: () => void;
+}
+
+export default function ThemeCard({
+  themeLabel,
+  disabled,
+  isSelected,
+  handleTheme
+}: ThemeCardProps) {
+  const isDark = themeLabel !== 'light';
+
+  function handleClick() {
+    if (disabled) return;
+    handleTheme();
+  }
+
+  return (
+    <div
+      className={cn(
+        'w-full relative cursor-pointer',
+        disabled ? 'opacity-30 cursor-not-allowed' : ''
+      )}
+      onClick={handleClick}
+    >
+      <div className="absolute inset-0 bg-transparent" />
+      <div
+        className={cn(
+          'flex flex-col items-center p-2 mx-auto gap-3 rounded-tl-sm rounded-tr-sm text-center border',
+          isDark ? 'bg-black' : 'bg-white'
+        )}
+      >
+        <Logo width={30} height={30} />
+        <div className="flex flex-col rounded-xl overflow-hidden">
+          <span className="w-full bg-primary text-white p-1 text-[10px]">
+            Terminal
+          </span>
+          <span
+            className={cn(
+              'p-2 pb-0 text-[10px]',
+              isDark ? 'text-white' : 'text-black'
+            )}
+          >
+            pip3 install -U swarms
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center text-sm gap-2 bg-foreground text-secondary rounded-bl-sm rounded-br-sm border-gray-700/100 border-t-2 py-2 px-4">
+        <div
+          className={cn(
+            'w-4 h-4 flex relative items-center justify-center border border-gray-400 rounded-sm',
+            isSelected
+              ? "bg-primary before:content-['✔'] before:absolute before:inline-block before:text-xs before:text-white"
+              : ''
+          )}
+        />
+        <span className="first-letter:capitalize">{themeLabel} default</span>
+      </div>
+    </div>
+  );
+}

--- a/shared/components/theme-toggle/index.tsx
+++ b/shared/components/theme-toggle/index.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import React, { useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/shared/components/ui/select';
+import { useTheme } from 'next-themes';
+
+const ThemeCard = dynamic(() => import('./components/theme-card'), {
+  ssr: false
+});
+
+enum THEMES {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system'
+}
+const themes = [THEMES.LIGHT, THEMES.DARK];
+const themeOptions = [
+  { label: 'Single theme', value: 'single' },
+  { label: 'Sync with your system', value: THEMES.SYSTEM }
+] as const;
+
+export default function ThemeToggle() {
+  const { setTheme, theme, resolvedTheme } = useTheme();
+  const [themeOption, setThemeOption] = useState(
+    theme === THEMES.SYSTEM ? THEMES.SYSTEM : 'single'
+  );
+
+  const placeholder = themeOptions.find(
+    (option) => option.value === themeOption
+  )?.label;
+
+  function handleThemeOptionChange(value: string) {
+    setThemeOption(value);
+
+    if (value === THEMES.SYSTEM) {
+      setTheme(THEMES.SYSTEM);
+    } else {
+      setTheme(THEMES.DARK);
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold">Theme Mode</h2>
+
+      <span className="mt-4 text-sm text-muted-foreground">
+        Select theme card or sync platform with your system theme
+      </span>
+
+      <div className="mt-1 mb-6">
+        <Select
+          onValueChange={(value) => {
+            handleThemeOptionChange(value);
+          }}
+          value={themeOption}
+        >
+          <SelectTrigger className="w-2/4">
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            {themeOptions?.map((option) => (
+              <SelectItem key={option.label} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center justify-center gap-4">
+        {themes.map((item) => (
+          <ThemeCard
+            key={item}
+            themeLabel={item}
+            disabled={theme === THEMES.SYSTEM}
+            isSelected={resolvedTheme === item}
+            handleTheme={() => setTheme(item)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/shared/components/theme-toggle/index.tsx
+++ b/shared/components/theme-toggle/index.tsx
@@ -61,7 +61,7 @@ export default function ThemeToggle() {
           }}
           value={themeOption}
         >
-          <SelectTrigger className="w-2/4">
+          <SelectTrigger className="xl:w-2/4">
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent>

--- a/shared/components/theme-toggle/index.tsx
+++ b/shared/components/theme-toggle/index.tsx
@@ -20,16 +20,17 @@ enum THEMES {
   DARK = 'dark',
   SYSTEM = 'system'
 }
-const themes = [THEMES.LIGHT, THEMES.DARK];
+const themes: THEMES[] = [THEMES.LIGHT, THEMES.DARK];
+const SINGLE = 'single';
 const themeOptions = [
-  { label: 'Single theme', value: 'single' },
+  { label: 'Single theme', value: SINGLE },
   { label: 'Sync with your system', value: THEMES.SYSTEM }
 ] as const;
 
 export default function ThemeToggle() {
   const { setTheme, theme, resolvedTheme } = useTheme();
   const [themeOption, setThemeOption] = useState(
-    theme === THEMES.SYSTEM ? THEMES.SYSTEM : 'single'
+    theme === THEMES.SYSTEM ? THEMES.SYSTEM : SINGLE
   );
 
   const placeholder = themeOptions.find(
@@ -39,11 +40,8 @@ export default function ThemeToggle() {
   function handleThemeOptionChange(value: string) {
     setThemeOption(value);
 
-    if (value === THEMES.SYSTEM) {
-      setTheme(THEMES.SYSTEM);
-    } else {
-      setTheme(THEMES.DARK);
-    }
+    if (value === THEMES.SYSTEM) return setTheme(THEMES.SYSTEM);
+    return setTheme(THEMES.DARK);
   }
 
   return (

--- a/shared/components/theme-toggle/index.tsx
+++ b/shared/components/theme-toggle/index.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import React, { useState } from 'react';
+import { useTheme } from 'next-themes';
+import { useState } from 'react';
+
 import {
   Select,
   SelectContent,
@@ -9,23 +11,11 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/shared/components/ui/select';
-import { useTheme } from 'next-themes';
+import { SINGLE, themeOptions, themes, THEMES } from '@/shared/constants/theme';
 
 const ThemeCard = dynamic(() => import('./components/theme-card'), {
   ssr: false
 });
-
-enum THEMES {
-  LIGHT = 'light',
-  DARK = 'dark',
-  SYSTEM = 'system'
-}
-const themes: THEMES[] = [THEMES.LIGHT, THEMES.DARK];
-const SINGLE = 'single';
-const themeOptions = [
-  { label: 'Single theme', value: SINGLE },
-  { label: 'Sync with your system', value: THEMES.SYSTEM }
-] as const;
 
 export default function ThemeToggle() {
   const { setTheme, theme, resolvedTheme } = useTheme();

--- a/shared/components/ui/AuthForms/EmailSignIn.tsx
+++ b/shared/components/ui/AuthForms/EmailSignIn.tsx
@@ -46,7 +46,7 @@ export default function EmailSignIn({
               autoCapitalize="none"
               autoComplete="email"
               autoCorrect="off"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
           </div>
           <Button

--- a/shared/components/ui/AuthForms/ForgotPassword.tsx
+++ b/shared/components/ui/AuthForms/ForgotPassword.tsx
@@ -46,7 +46,7 @@ export default function ForgotPassword({
               autoCapitalize="none"
               autoComplete="email"
               autoCorrect="off"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
           </div>
           <Button

--- a/shared/components/ui/AuthForms/PasswordSignIn.tsx
+++ b/shared/components/ui/AuthForms/PasswordSignIn.tsx
@@ -44,7 +44,7 @@ export default function PasswordSignIn({
               autoCapitalize="none"
               autoComplete="email"
               autoCorrect="off"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
             <label htmlFor="password">Password</label>
             <input
@@ -53,7 +53,7 @@ export default function PasswordSignIn({
               type="password"
               name="password"
               autoComplete="current-password"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
           </div>
           <Button

--- a/shared/components/ui/AuthForms/Signup.tsx
+++ b/shared/components/ui/AuthForms/Signup.tsx
@@ -43,7 +43,7 @@ export default function SignUp({ allowEmail, redirectMethod }: SignUpProps) {
               autoCapitalize="none"
               autoComplete="email"
               autoCorrect="off"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
             <label htmlFor="password">Password</label>
             <input
@@ -52,7 +52,7 @@ export default function SignUp({ allowEmail, redirectMethod }: SignUpProps) {
               type="password"
               name="password"
               autoComplete="current-password"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
           </div>
           <Button

--- a/shared/components/ui/AuthForms/UpdatePassword.tsx
+++ b/shared/components/ui/AuthForms/UpdatePassword.tsx
@@ -38,7 +38,7 @@ export default function UpdatePassword({
               type="password"
               name="password"
               autoComplete="current-password"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
             <label htmlFor="passwordConfirm">Confirm New Password</label>
             <input
@@ -47,7 +47,7 @@ export default function UpdatePassword({
               type="password"
               name="passwordConfirm"
               autoComplete="current-password"
-              className="w-full p-3 rounded-md bg-zinc-800"
+              className="w-full p-3 rounded-md bg-zinc-800 text-white"
             />
           </div>
           <Button

--- a/shared/components/ui/Button/index.tsx
+++ b/shared/components/ui/Button/index.tsx
@@ -16,6 +16,8 @@ const buttonVariants = cva(
           'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        foreground: 
+          'bg-foreground text-background hover:bg-foreground/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline'
       },

--- a/shared/components/ui/Footer/Footer.tsx
+++ b/shared/components/ui/Footer/Footer.tsx
@@ -118,8 +118,8 @@ export default function Footer() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col items-center justify-between py-12 space-y-4 md:flex-row bg-zinc-900">
-        <div>
+      <div className="flex flex-col items-center justify-between py-12 space-y-4 text-white md:flex-row bg-zinc-900">
+        <div className='w-full text-center'>
           <span>
             &copy; {new Date().getFullYear()} TGSC, Inc. All rights reserved.
           </span>

--- a/shared/constants/theme.ts
+++ b/shared/constants/theme.ts
@@ -1,0 +1,19 @@
+export enum THEMES {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system'
+}
+
+export const themes: THEMES[] = [THEMES.LIGHT, THEMES.DARK];
+
+export const SINGLE = 'single';
+
+export const themeOptions = [
+  { label: 'Single theme', value: SINGLE },
+  { label: 'Sync with your system', value: THEMES.SYSTEM }
+] as const;
+
+export const StrokeColor = {
+  DARK: '#00000068',
+  LIGHT: '#ffffff'
+};


### PR DESCRIPTION
# PR Description

Major changes for this PR includes:

> **Note** that this does not entail _refactoring_ of existing color setup

- Displaying the correct text colors for texts on light mode
- Added a theme toggle component to the User's Account
- Added a select element for users to choose between toggling cards or syncing their theme with their systems


## Changes & Additions
- Theme Toggle Component - (`shared/components/theme-toggle/index.tsx`)
- Theme Card Component - a child component of the Theme toggle (`shared/components/theme-toggle/components/theme-card.tsx`)
- Theme Constants - (`shared/constants/theme.ts`)

### Assets

- Desktop (Dark)
<img width="454" alt="Screenshot 2024-04-08 at 14 22 01" src="https://github.com/kyegomez/swarms-platform/assets/68924490/ae7ae8bf-86ae-4a81-8837-f95d82d6e265">

- Mobile (Light)
<img width="377" alt="Screenshot 2024-04-08 at 14 23 23" src="https://github.com/kyegomez/swarms-platform/assets/68924490/e79185ae-11d0-4770-ac2c-791288ff87eb">
