### PR TITLE
[FEAT] add toggle button

### DIFF
--- a/shared/components/panel-layout/components/sidebar.tsx
+++ b/shared/components/panel-layout/components/sidebar.tsx
@@ -6,12 +6,14 @@ import {
   LayoutDashboard,
   LockKeyhole,
   Menu,
-  SquareChevronRight, User,
-  X
+  SquareChevronRight,
+  User,
+  X,
+  ChevronsLeft
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SignOut } from '@/shared/utils/auth-helpers/server';
 import { handleRequest } from '@/shared/utils/auth-helpers/client';
 import Logo from '../../icons/Logo';
@@ -72,15 +74,49 @@ const panelMenu: {
   }
 ];
 
+const collapsedMenu = 'collapsedMenu';
 const PanelLayoutSidebar = () => {
   const path = usePathname();
   const router = useRouter();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  function toggleSidebar() {
+    setIsCollapsed(!isCollapsed);
+    localStorage.setItem(collapsedMenu, JSON.stringify(!isCollapsed));
+  }
+
+  useEffect(() => {
+    const value = localStorage.getItem(collapsedMenu);
+    if (value) {
+      setIsCollapsed(JSON.parse(value));
+    }
+  }, []);
 
   return (
     <>
       {/* desktop */}
-      <div className="flex flex-col flex-shrink-0 w-[250px] h-screen border-r border-gray-900 max-md:hidden">
-        <div className="flex flex-col justify-between p-4 w-full h-screen ">
+      <div
+        className={cn(
+          'flex flex-col relative flex-shrink-0 max-w-[250px] w-full transition-all ease-out duration-300 translate-x-0 h-screen border-r border-gray-900 max-lg:hidden',
+          isCollapsed && 'max-w-0 -translate-x-full'
+        )}
+      >
+        <Button
+          onClick={toggleSidebar}
+          className={cn(
+            'rounded-full absolute -right-4 top-9 max-w-8 h-8 w-full cursor-pointer flex p-0 transition-all duration-300 shadow-md',
+            isCollapsed &&
+              'rounded-l-[12px] rounded-r-sm top-28 -right-10 max-w-[none] w-12 h-[30px]'
+          )}
+        >
+          {isCollapsed ? <Menu /> : <ChevronsLeft />}
+        </Button>
+        <div
+          className={cn(
+            'flex flex-col justify-between p-4 w-full h-screen visible',
+            isCollapsed && 'invisible'
+          )}
+        >
           <div className="h-full">
             <div>
               {/* logo */}
@@ -140,7 +176,7 @@ const PanelLayoutSidebar = () => {
       </div>
 
       {/* mobile */}
-      <div className="md:hidden">
+      <div className="lg:hidden">
         <Drawer direction="left">
           <DrawerTrigger asChild>
             <div className="flex w-full h-auto py-2 backdrop-blur-md bg-background/70 top-0 absolute z-[20] ">

--- a/shared/components/panel-layout/components/sidebar.tsx
+++ b/shared/components/panel-layout/components/sidebar.tsx
@@ -13,9 +13,10 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { SignOut } from '@/shared/utils/auth-helpers/server';
 import { handleRequest } from '@/shared/utils/auth-helpers/client';
+import useToggle from '@/shared/hooks/toggle';
 import Logo from '../../icons/Logo';
 import { PLATFORM } from '@/shared/constants/links';
 import {
@@ -78,19 +79,7 @@ const collapsedMenu = 'collapsedMenu';
 const PanelLayoutSidebar = () => {
   const path = usePathname();
   const router = useRouter();
-  const [isCollapsed, setIsCollapsed] = useState(false);
-
-  function toggleSidebar() {
-    setIsCollapsed(!isCollapsed);
-    localStorage.setItem(collapsedMenu, JSON.stringify(!isCollapsed));
-  }
-
-  useEffect(() => {
-    const value = localStorage.getItem(collapsedMenu);
-    if (value) {
-      setIsCollapsed(JSON.parse(value));
-    }
-  }, []);
+  const { isOn, toggle } = useToggle("off", collapsedMenu);
 
   return (
     <>
@@ -98,23 +87,23 @@ const PanelLayoutSidebar = () => {
       <div
         className={cn(
           'flex flex-col relative flex-shrink-0 max-w-[250px] w-full transition-all ease-out duration-300 translate-x-0 h-screen border-r border-gray-900 max-lg:hidden',
-          isCollapsed && 'max-w-0 -translate-x-full'
+          isOn && 'max-w-0 -translate-x-full'
         )}
       >
         <Button
-          onClick={toggleSidebar}
+          onClick={toggle}
           className={cn(
             'rounded-full absolute -right-4 top-9 max-w-8 h-8 w-full cursor-pointer flex p-0 transition-all duration-300 shadow-md',
-            isCollapsed &&
+            isOn &&
               'rounded-l-[12px] rounded-r-sm top-28 -right-10 max-w-[none] w-12 h-[30px]'
           )}
         >
-          {isCollapsed ? <Menu /> : <ChevronsLeft />}
+          {isOn ? <Menu /> : <ChevronsLeft />}
         </Button>
         <div
           className={cn(
             'flex flex-col justify-between p-4 w-full h-screen visible',
-            isCollapsed && 'invisible'
+            isOn && 'invisible'
           )}
         >
           <div className="h-full">

--- a/shared/components/panel-layout/index.tsx
+++ b/shared/components/panel-layout/index.tsx
@@ -10,7 +10,7 @@ const PanelLayout = ({ children }: { children: React.ReactNode }) => {
         <PanelLayoutSidebar />
 
         {/* content */}
-        <div className="flex container h-full overflow-scroll mx-auto py-8 max-md:z-10 max-md:pt-16">
+        <div className="flex container lg:max-w-7xl lg:px-12 h-full overflow-scroll mx-auto py-8 max-lg:z-10 max-lg:pt-16">
           {children}
         </div>
       </div>

--- a/shared/components/panel-layout/index.tsx
+++ b/shared/components/panel-layout/index.tsx
@@ -10,7 +10,7 @@ const PanelLayout = ({ children }: { children: React.ReactNode }) => {
         <PanelLayoutSidebar />
 
         {/* content */}
-        <div className="flex container lg:max-w-7xl lg:px-12 h-full overflow-scroll mx-auto py-8 max-lg:z-10 max-lg:pt-16">
+        <div className="flex container lg:max-w-7xl lg:px-12 h-full overflow-scroll no-scrollbar mx-auto py-8 max-lg:z-10 max-lg:pt-16">
           {children}
         </div>
       </div>

--- a/shared/hooks/toggle.ts
+++ b/shared/hooks/toggle.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+
+export default function useToggle(init?: 'on' | 'off', storageKey?: string) {
+  const [toggleState, setToggle] = useState(
+    init || (storageKey ? localStorage.getItem(storageKey) || 'off' : 'off')
+  );
+
+  useEffect(() => {
+    if (storageKey) {
+      const storedValue = localStorage.getItem(storageKey);
+      if (storedValue !== null) {
+        setToggle(storedValue);
+      }
+    }
+  }, [storageKey]);
+
+  function setOn() {
+    setToggle('on');
+    if (storageKey) {
+      localStorage.setItem(storageKey, 'on');
+    }
+  }
+
+  function setOff() {
+    setToggle('off');
+    if (storageKey) {
+      localStorage.setItem(storageKey, 'off');
+    }
+  }
+
+  function toggle() {
+    if (toggleState === 'off') setOn();
+    else setOff();
+  }
+
+  return {
+    isOn: toggleState === 'on',
+    isOff: toggleState === 'off',
+    setOn,
+    setOff,
+    toggle
+  };
+}

--- a/shared/styles/main.css
+++ b/shared/styles/main.css
@@ -1,8 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
- 
-
 
 @layer base {
   :root {
@@ -51,13 +49,22 @@
   }
 }
 
-
- 
 @layer base {
   * {
     @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none; /* Chrome, Safari and Opera */
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
   }
 }


### PR DESCRIPTION
# PR Description

Major changes for this PR includes:

- Adding a toggle button to the sidebar
- Changes to max-width of dashboard container
- Added a `useToggle` hook for future uses
- IPad Mini devices uses the same layout as mobile for protected/dashboard pages


## Changes & Additions
- useToggle hook - (`shared/hooks/toggle.ts`)
- Sidebar Component - (`shared/components/panel-layout/components/sidebar.tsx`)
- Panel Layout - (`shared/components/panel-layout/index.tsx`)

### Assets

- Open Sidebar
<img width="747" alt="Screenshot 2024-04-11 at 23 22 46" src="https://github.com/kyegomez/swarms-platform/assets/68924490/2469505a-cc57-4c81-a929-697cdb5ed654">


- Closed Sidebar
<img width="747" alt="Screenshot 2024-04-11 at 23 23 03" src="https://github.com/kyegomez/swarms-platform/assets/68924490/3c01bce2-c153-404c-a0d2-50cd04bd8f0c">

