### PR TITLE
feat: redirect authenticated users to explorer page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,7 @@
-import { type NextRequest } from 'next/server';
-import { updateSession } from '@/shared/utils/supabase/middleware';
+import { stackMiddlewares } from '@/shared/utils/stack-middlewares/stack';
+import { middlewares } from '@/shared/utils/stack-middlewares/middlewares';
 
-export async function middleware(request: NextRequest) {
-  return await updateSession(request);
-}
+export default stackMiddlewares(middlewares);
 
 export const config = {
   matcher: [

--- a/shared/utils/stack-middlewares/middlewares.ts
+++ b/shared/utils/stack-middlewares/middlewares.ts
@@ -1,0 +1,43 @@
+import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+import { MiddlewareFactory } from './types';
+import { createClient } from '@/shared/utils/supabase/server';
+import { updateSession } from '@/shared/utils/supabase/middleware';
+
+const withAuthentication: MiddlewareFactory = (next) => {
+  // Variable used to prevent multiple redirects
+  let redirected = false;
+
+  return async (req: NextRequest, _next: NextFetchEvent) => {
+    // Get the previous URL from the headers
+    const previousUrl = req.headers.get('referer');
+
+    const supabase = createClient();
+    const {
+      data: { user }
+    } = await supabase.auth.getUser();
+
+    if (user && req.nextUrl.pathname === '/') {
+      if (!redirected) {
+        redirected = true;
+        return NextResponse.redirect(
+          new URL('/platform/explorer', req.nextUrl)
+        );
+      }
+
+      return NextResponse.redirect(
+        new URL(previousUrl || '/platform/explorer', req.nextUrl)
+      );
+    }
+
+    return next(req, _next);
+  };
+};
+
+const withUpdateSession: MiddlewareFactory = (next) => {
+  return async (req: NextRequest, _next: NextFetchEvent) => {
+    await updateSession(req);
+    return next(req, _next);
+  };
+};
+
+export const middlewares = [withUpdateSession, withAuthentication];

--- a/shared/utils/stack-middlewares/stack.ts
+++ b/shared/utils/stack-middlewares/stack.ts
@@ -1,0 +1,19 @@
+import { NextMiddleware, NextResponse } from 'next/server';
+import { MiddlewareFactory } from './types';
+
+/**
+ * @param functions refers to middleware functions to be chained together
+ * @param index current index of the middleware
+ * @returns the next middleware function after the current middleware
+ */
+export function stackMiddlewares(
+  functions: MiddlewareFactory[] = [],
+  index = 0
+): NextMiddleware {
+  const current = functions[index];
+  if (current) {
+    const next = stackMiddlewares(functions, index + 1);
+    return current(next);
+  }
+  return () => NextResponse.next();
+}

--- a/shared/utils/stack-middlewares/types.ts
+++ b/shared/utils/stack-middlewares/types.ts
@@ -1,0 +1,3 @@
+import { NextMiddleware } from "next/server";
+
+export type MiddlewareFactory = (middleware: NextMiddleware) => NextMiddleware;


### PR DESCRIPTION
## PR Description

Created a chaining middleware logic `stackMiddlewares` to handle more than one middleware simultaneously, `withAuthentication` middleware contains the logic to redirect authenticated users to explorer page on page mount.

Authenticated users cannot access the home page thereby remaining in the current page they are trying to access the homepage from.